### PR TITLE
removed confusing instruction

### DIFF
--- a/alu.py
+++ b/alu.py
@@ -21,9 +21,13 @@ class ALU(object):
     # in hardware we would use a multiplexer circuit to connect the
     # inputs and output to the selected circuitry for each operation.
     ALU_OPS = {
-        # FIXME:  You need functions for ADD, SUB, MUL, DIV
+        # You need functions for ADD, SUB, MUL, DIV
         # Note that DIV is integer division, like // and not like /
-        #
+        OpCode.ADD: lambda x, y: x + y,
+        OpCode.MUL: lambda x, y: x * y,
+        OpCode.SUB: lambda x, y: x - y,
+        OpCode.DIV: lambda x, y: x // y,
+
         # For memory access operations load, store, the ALU
         # performs the address calculation
         OpCode.LOAD: lambda x, y: x + y,

--- a/bitfield.py
+++ b/bitfield.py
@@ -21,11 +21,11 @@ logging.basicConfig()
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
-WORD_SIZE = 32 
+WORD_SIZE = 32
 
 
 class BitField(object):
-    """A BitField object handles insertion and 
+    """A BitField object handles insertion and
     extraction of one field within an integer.
     """
     pass
@@ -57,9 +57,7 @@ class BitField(object):
     #
     #   method extract_signed does the same as extract, but then if the
     #   sign bit of the field is 1, it sign-extends the value to form the
-    #   appropriate negative integer.  extract_signed could call the function
-    #   extract_signed below, but you may prefer to incorporate that logic into
-    #   the extract_signed method.
+    #   appropriate negative integer.
 
 
 # Sign extension is a little bit wacky in Python, because Python
@@ -106,4 +104,3 @@ def sign_extend(field: int, width: int) -> int:
         return extended
     else:
         return field
-

--- a/bitfield.py
+++ b/bitfield.py
@@ -28,44 +28,85 @@ class BitField(object):
     """A BitField object handles insertion and
     extraction of one field within an integer.
     """
-    pass
-    # FIXME:
-    #    The constructor should take two integers, from_bit and to_bit,
-    #    indicating the bounds of the field.  Unlike a Python range, these
-    #    are inclusive, e.g., if from_bit=0 and to_bit = 4, then it is a
-    #    5 bit field with bits numbered 0, 1, 2, 3, 4.
-    #
-    #    You might want to precompute some additional values in the constructor
-    #    rather than recomputing them each time you insert or extract a value.
-    #    I precomputed the field width (used in several places), a mask (for
-    #    extracting the bits of interest), the inverse of the mask (for clearing
-    #    a field before I insert a new value into it), and a couple of other values
-    #    that could be useful to have in sign extension (see the sign_extend
-    #    function below).
-    #
-    #    method insert takes a field value (an int) and a word (an int)
-    #    and returns the word with the field value replacing the old contents
-    #    of that field of the word.
-    #    For example,
-    #      if word is   xaa00aa00 and
-    #      field_val is x0000000f
-    #      and the field is bits 4..7
-    #      then insert gives xaa00aaf0
-    #
-    #   method extract takes a word and returns the value of the field
-    #   (which was set in the constructor)
-    #
-    #   method extract_signed does the same as extract, but then if the
-    #   sign bit of the field is 1, it sign-extends the value to form the
-    #   appropriate negative integer.
 
+    def __init__(self, from_bit: int, to_bit: int) -> None:
+        """Tool for inserting and extracting bits
+        from_bit ... to_bit, where 0 is the low-order
+        bit and 31 is the high-order bit of an unsigned
+        32-bit integer. For example, the low-order 4 bits
+        could be represented by from_bit=0, to_bit=3.
+        """
+        assert 0 <= from_bit < WORD_SIZE
+        assert from_bit <= to_bit <= WORD_SIZE
+
+        self.from_bit = from_bit
+        self.to_bit = to_bit
+
+        self.field_width = 1 + to_bit - from_bit
+
+        # Masks for the field
+        #   1s in the field position, 0s elsewhere
+        self.mask = self._construct_mask(self.field_width) << from_bit
+
+        #   0s in the field position, 1s elsewhere
+        self.maskout = ~ self.mask
+
+        # Sign extension complement and mask
+        self.comp = 1 << self.field_width
+        self.sign_bit = 1 << (self.field_width - 1)
+
+    def _construct_mask(self, width: int) -> int:
+        """Construct a mask of required width in the
+        low-order bits.
+        """
+        assert width >= 0
+        mask = 0
+        for bit in range(width):
+            mask = (mask << 1) + 1
+        return mask
+
+    def insert(self, field_value: int, word: int) -> int:
+        """Insert value of field into word.
+        For example,
+          if word is   xaa00aa00 and
+          field_val is x0000000f
+          and the field is bits 4..7
+        then insert gives xaa00aaf0
+        """
+        # The field value, shifted into place and masked
+        in_place = field_value << self.from_bit
+        in_place = in_place & self.mask
+        # Clear bits from field in target value
+        word &= self.maskout
+        # Combine
+        return word | in_place
+
+    def extract(self, word: int) -> int:
+        """Extract the bitfield and return it in the
+        low-order bits. For example, if we are extracting
+        the high-order five bits, the result will be an
+        integer between 0 and 31.
+        """
+        field = word & self.mask
+        return field >> self.from_bit
+
+    def extract_signed(self, word: int) -> int:
+        """Extract the bitfield and return it in the
+        low order bits, sign-extended.
+        """
+        unsigned = self.extract(word)
+        # Sign extend if negative
+        if unsigned >> (self.field_width - 1) == 1:  # if signed bit is set, sign extend
+            return unsigned - self.comp
+        else:
+            return unsigned
 
 # Sign extension is a little bit wacky in Python, because Python
 # doesn't really use 32-bit integers ... rather it uses a special
 # variable-length bit-string format, which makes *most* logical
-# operations work in the extpected way  *most* of the time, but
+# operations work in the expected way *most* of the time, but
 # with some differences that show up especially for negative
-# numbers.  I've written this sign extension function for you so
+# numbers. I've written this sign extension function for you so
 # that you don't have to spend time plotting a way to make it work.
 # You'll probably want to convert it to a method in the BitField
 # class.
@@ -83,7 +124,8 @@ class BitField(object):
 #
 #    Sign extension distinguishes these cases by checking
 #    the "sign bit", the highest bit in the field.
-#
+
+
 def sign_extend(field: int, width: int) -> int:
     """Interpret field as a signed integer with width bits.
     If the sign bit is zero, it is positive.  If the sign bit
@@ -93,12 +135,12 @@ def sign_extend(field: int, width: int) -> int:
     """
     log.debug("Sign extending {} ({}) in field of {} bits".format(field, bin(field), width))
     assert width > 1
-    assert field >= 0 and field < 1 << (width + 1)
-    sign_bit = 1 << (width - 1) # will have form 1000... for width of field
-    mask = sign_bit - 1         # will have form 0111... for width of field
+    assert 0 <= field < (1 << (width + 1))
+    sign_bit = 1 << (width - 1)  # will have form 1000... for width of field
+    mask = sign_bit - 1          # will have form 0111... for width of field
     if (field & sign_bit):
         # It's negative; sign extend it
-        log.debug("Complementing by subtracting 2^{}={}".format(width-1,sign_bit))
+        log.debug("Complementing by subtracting 2^{}={}".format(width-1, sign_bit))
         extended = (field & mask) - sign_bit
         log.debug("Should return {} ({})".format(extended, bin(extended)))
         return extended

--- a/test_alu.py
+++ b/test_alu.py
@@ -27,10 +27,10 @@ class TestALU(unittest.TestCase):
         self.alu = alu.ALU()
 
     def test_halt(self):
-        self.assertEqual(self.alu.exec(OpCode.HALT,42,64), (0,CondFlag.Z))
+        self.assertEqual(self.alu.exec(OpCode.HALT, 42, 64), (0, CondFlag.Z))
 
     def test_load(self):
-        self.assertEqual(self.alu.exec(OpCode.LOAD,16,32), (48,CondFlag.P))
+        self.assertEqual(self.alu.exec(OpCode.LOAD, 16, 32), (48, CondFlag.P))
 
     def test_store(self):
         self.assertEqual(self.alu.exec(OpCode.STORE, 12, 18), (30, CondFlag.P))

--- a/test_instr_format.py
+++ b/test_instr_format.py
@@ -22,8 +22,8 @@ class test_instruction(unittest.TestCase):
 
     def test_instruction_from_dict(self):
         """Simple smoke test: Can I make an instruction from a dict?"""
-        d = { "opcode": "MUL", "predicate": "ALWAYS", "target": "r1",
-           "src1": "r2", "src2": "r3", "offset": "-12" }
+        d = {"opcode": "MUL", "predicate": "ALWAYS", "target": "r1",
+             "src1": "r2", "src2": "r3", "offset": "-12"}
         instr = instr_format.instruction_from_dict(d)
         self.assertEqual(instr.op, OpCode.MUL)
         self.assertEqual(instr.cond, CondFlag.ALWAYS)
@@ -42,4 +42,3 @@ class test_instruction(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
Just removed the comment:
>     #   extract_signed could call the function
>     #   extract_signed below, but you may prefer to incorporate that logic into
>     #   the extract_signed method.